### PR TITLE
fix/unified-dropdown-missing-on-homepage

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1196,13 +1196,16 @@
                                             <span x-text="homepageFolders().length === 1 ? 'folder' : 'folders'"></span>
                                         </span>
                                         <button 
-                                            @click="createNote()"
-                                            class="ml-auto px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors"
+                                            @click="dropdownTargetFolder = selectedHomepageFolder; toggleNewDropdown($event)"
+                                            class="ml-auto px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors flex items-center gap-2"
                                             style="background-color: var(--accent-primary);"
                                             onmouseover="this.style.backgroundColor='var(--accent-hover)'"
                                             onmouseout="this.style.backgroundColor='var(--accent-primary)'"
                                         >
-                                            + New Note
+                                            <span>+ New</span>
+                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                            </svg>
                                         </button>
                                     </div>
                                 </div>
@@ -1217,13 +1220,16 @@
                                     <h2 class="text-2xl font-bold mb-2" style="color: var(--text-primary);">No notes yet</h2>
                                     <p class="mb-6" style="color: var(--text-secondary);">Create your first note to get started</p>
                                     <button 
-                                        @click="createNote()"
-                                        class="px-6 py-3 text-sm font-medium text-white rounded-lg transition-colors"
+                                        @click="dropdownTargetFolder = selectedHomepageFolder; toggleNewDropdown($event)"
+                                        class="px-6 py-3 text-sm font-medium text-white rounded-lg transition-colors flex items-center gap-2"
                                         style="background-color: var(--accent-primary);"
                                         onmouseover="this.style.backgroundColor='var(--accent-hover)'"
                                         onmouseout="this.style.backgroundColor='var(--accent-primary)'"
                                     >
-                                        Create Your First Note
+                                        <span>Create Your First Note</span>
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                        </svg>
                                     </button>
                                 </div>
                             </template>


### PR DESCRIPTION
As per issue #44 

## Changes
- Change callbacks on the homepage buttons to use unified dropdown
- Adjust styling to indicate dropdown functionality
- Create buttons on the homepage now create the items at whatever folder you're currently viewing

## Testing
Created notes, folders, notes from templates at various folder depths


## Empty Homepage UI

### Before
<img width="1624" height="945" alt="image" src="https://github.com/user-attachments/assets/30144efb-2d5f-4b63-a1d1-42ef9aefacea" />

### After
<img width="1641" height="944" alt="image" src="https://github.com/user-attachments/assets/8a08989f-e674-45ec-b3df-3cd11d3aec32" />
<img width="377" height="466" alt="image" src="https://github.com/user-attachments/assets/2bf73047-8cbb-4657-8a6b-b85f8c3a4932" />


## Occupied Homepage UI

### Before
<img width="1620" height="946" alt="image" src="https://github.com/user-attachments/assets/1d1219bc-7f9b-444d-853f-cf260c34d726" />


### After
<img width="1639" height="945" alt="image" src="https://github.com/user-attachments/assets/0344b759-a620-4c1b-80cd-9db272871bad" />
<img width="262" height="277" alt="image" src="https://github.com/user-attachments/assets/07d4cbbc-4424-4bfc-a0dd-6ec4095afd60" />
