### PR TITLE
fix(stats): implement regex for sentences, lists, and tables

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2962,6 +2962,15 @@ function noteApp() {
             // Paragraph count
             const paragraphs = content.split('\n\n').filter(p => p.trim()).length;
             
+            // Sentences: punctuation [.!?]+ followed by space or end-of-string
+            const sentences = (content.match(/[.!?]+(?:\s|$)/g) || []).length;
+            
+            // List items: lines starting with -, *, + or a number (e.g. 1., 10.), excluding tasks [-]
+            const listItems = (content.match(/^\s*(?:[-*+]|\d+\.)\s+(?!\[)/gm) || []).length;
+            
+            // Tables: separator rows containing both '|' and '---'
+            const tables = (content.match(/^(?=.*\|)(?=.*---).*$/gm) || []).length;
+            
             // Link count
             const linkMatches = content.match(/\[([^\]]+)\]\(([^\)]+)\)/g) || [];
             const links = linkMatches.length;
@@ -2990,11 +2999,14 @@ function noteApp() {
             
             this.noteStats = {
                 words,
+                sentences,
                 characters: chars,
                 total_characters: totalChars,
                 reading_time_minutes: readingTime,
                 lines,
                 paragraphs,
+                list_items: listItems,
+                tables,
                 links,
                 internal_links: internalLinks,
                 external_links: links - internalLinks,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1567,6 +1567,24 @@
                                     <div class="font-semibold" style="color: var(--text-primary);" x-text="noteStats ? noteStats.lines.toLocaleString() : '0'"></div>
                                 </div>
                                 
+                                <!-- Sentences -->
+                                <div>
+                                    <div class="text-xs" style="color: var(--text-tertiary);">Sentences</div>
+                                    <div class="font-semibold" style="color: var(--text-primary);" x-text="noteStats ? noteStats.sentences.toLocaleString() : '0'"></div>
+                                </div>
+
+                                <!-- Lists -->
+                                <div>
+                                    <div class="text-xs" style="color: var(--text-tertiary);">Lists</div>
+                                    <div class="font-semibold" style="color: var(--text-primary);" x-text="noteStats ? noteStats.list_items.toLocaleString() : '0'"></div>
+                                </div>
+
+                                <!-- Tables -->
+                                <div>
+                                    <div class="text-xs" style="color: var(--text-tertiary);">Tables</div>
+                                    <div class="font-semibold" style="color: var(--text-primary);" x-text="noteStats ? noteStats.tables.toLocaleString() : '0'"></div>
+                                </div>
+                                
                                 <!-- Links -->
                                 <template x-if="noteStats && noteStats.links > 0">
                                     <div>

--- a/plugins/note_stats.py
+++ b/plugins/note_stats.py
@@ -40,6 +40,19 @@ class Plugin:
         
         # Paragraph count (blocks separated by blank lines)
         paragraphs = len([p for p in content.split('\n\n') if p.strip()])
+
+        # Sentence count: punctuation [.!?]+ followed by space or end-of-string
+        sentences = len(re.findall(r'[.!?]+(?:\s|$)', content))
+
+        # List items: lines starting with -, *, + or a number (e.g. 1., 10.), excluding tasks [-]
+        list_items = len(
+            re.findall(r'^\s*(?:[-*+]|\d+\.)\s+(?!\[)', content, re.MULTILINE)
+        )
+
+        # Tables: count separator rows containing both '|' and '---'
+        tables = len(
+            re.findall(r'^(?=.*\|)(?=.*---).*$', content, re.MULTILINE)
+        )
         
         # Markdown link count
         links = len(re.findall(r'\[([^\]]+)\]\(([^\)]+)\)', content))
@@ -71,11 +84,14 @@ class Plugin:
         
         return {
             'words': words,
+            'sentences': sentences,
             'characters': chars,
             'total_characters': total_chars,
             'reading_time_minutes': reading_time,
             'lines': lines,
             'paragraphs': paragraphs,
+            'list_items': list_items,
+            'tables': tables,
             'links': links,
             'internal_links': internal_links,
             'external_links': links - internal_links,
@@ -129,7 +145,14 @@ class Plugin:
         
         # Log key statistics
         print(f"📊 {note_path}:")
-        print(f"   {stats['words']:,} words | {stats['reading_time_minutes']}m read | {stats['lines']:,} lines")
+        print(
+            f"   {stats['words']:,} words | "
+            f"{stats['sentences']:,} sentences | "
+            f"{stats['reading_time_minutes']}m read | "
+            f"{stats['lines']:,} lines | "
+            f"{stats['list_items']:,} lists | "
+            f"{stats['tables']:,} tables"
+        )
         
         if stats['links'] > 0:
             print(f"   {stats['links']} links ({stats['internal_links']} internal)")


### PR DESCRIPTION
## Changes Implemented

### **Backend (`note_stats.py`):**
- Added `re` patterns to count:
  - **Sentences** (punctuation approximation)
  - **List Items** (bullets/numbers)
  - **Tables** (separator rows)
- **Fix:** Added a negative lookahead `(?!\[[ xX]\])` to the List logic so **Tasks (checkboxes)** are not double-counted as List Items.
- Updated the console logger to display these new metrics on save.

### **Frontend (`app.js` & `index.html`):**
- Mirrored the Regex logic in `app.js` to ensure **instant update** behavior while editing.
- Added **3 new cards** to the Note Statistics panel:
  - Sentences  
  - Lists  
  - Tables  

## Technical Approach

### **Zero Bloat**
Used Python’s built-in `re` module and JavaScript’s `match()` methods.  
No external NLP packages (NLP, SpaCy, etc.) were introduced.

### **Verification**
- Tested on a file containing a mix of:
  - Bullets  
  - Numbered Lists  
  - Tasks (checkboxes)  
  - Tables  
 
<img width="1680" height="862" alt="image" src="https://github.com/user-attachments/assets/0f7c2839-f262-45e8-8983-ab71ac4bd58a" />

