### PR TITLE
feat(search): implement KWIC context snippets and UI display

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -933,9 +933,10 @@
                                 :style="currentNote === note.path ? 'background-color: var(--accent-light); color: var(--accent-primary);' : 'color: var(--text-primary);'"
                                 onmouseover="if(this.style.backgroundColor !== 'var(--accent-light)') this.style.backgroundColor='var(--bg-hover)'"
                                 onmouseout="if(this.style.backgroundColor !== 'var(--accent-light)') this.style.backgroundColor='transparent'"
+                                :title="note.path"
                             >
                                 <div class="font-medium truncate" x-text="note.name"></div>
-                                <div class="text-xs truncate" style="color: var(--text-tertiary);" x-text="note.folder || 'Root'"></div>
+                                <div class="text-xs truncate" style="color: var(--text-tertiary);" x-text="(note.matches && note.matches.length > 0) ? note.matches[0].context : (note.folder || 'Root')"></div>
                             </div>
                         </template>
                     </div>


### PR DESCRIPTION
This PR upgrades the search experience by exposing contextual snippets in the sidebar, allowing users to identify relevant notes without clicking them. This addresses the feedback discussed in Issue #59.

### Changes Implemented:

**Backend (utils.py):**

- Refactored search extraction from line-based to character-based.
- Now extracts ±30 characters around the match (KWIC - Key Word In Context).
- Sanitizes newlines (replaces with spaces) to ensure UI stability.
- **Zero Bloat**: Implemented using standard Python re module; no new dependencies added.

**Frontend (index.html):**

- **Context Display**: Replaced the static "Folder Name" with the dynamic match context (e.g., ...launch date is definitely **Sept**...) when a search match exists.
- **Tooltip**: Added a native title tooltip to show the full note location (path/to/note.md) on hover.
- **Layout**: Preserved the existing sidebar height and styling (truncated, no clutter).

**Verification:**

**Scenario**: Searched for a keyword ("September") inside a paragraph.

**Result**: The sidebar correctly displays the surrounding sentence snippet instead of the folder name.

**Tooltip**: Hovering the item reveals the full file path.

<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/53554b7f-7c15-439e-915b-ccbe4468b7e1" />
