### PR TITLE
Allow entered URL note path to include file extension .md

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1782,7 +1782,7 @@ function noteApp() {
         // Load note from URL path
         loadNoteFromURL() {
             // Get path from URL (e.g., /folder/note or /note)
-            const path = window.location.pathname;
+            const path = window.location.pathname.removesuffix(".md");
             
             // Skip if root path or static assets
             if (path === '/' || path.startsWith('/static/') || path.startsWith('/api/')) {


### PR DESCRIPTION
MKdocs and Zensical allow for an edit button on the page. When configured to use NoteDiscovery as the editor, the URL contains the full files name with extension `.md`

This PR checks if the URL entered contains the notes file extension `.md`,  and if so removes the .md from URL

<img width="1121" height="220" alt="Screenshot 2025-12-09 at 7 49 25 pm" src="https://github.com/user-attachments/assets/77e53f42-215e-403c-a205-833416dd803b" />
