### PR TITLE
Add extra date-related template variables: year, month and day

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -774,6 +774,9 @@ def apply_template_placeholders(content: str, note_path: str) -> str:
     
     Supported placeholders:
         {{date}}      - Current date (YYYY-MM-DD)
+        {{year}}      - Current year (YYYY)
+        {{month}}     - Current month (MM)
+        {{day}}       - Current day (DD)
         {{time}}      - Current time (HH:MM:SS)
         {{datetime}}  - Current datetime (YYYY-MM-DD HH:MM:SS)
         {{timestamp}} - Unix timestamp
@@ -794,6 +797,9 @@ def apply_template_placeholders(content: str, note_path: str) -> str:
         '{{date}}': now.strftime('%Y-%m-%d'),
         '{{time}}': now.strftime('%H:%M:%S'),
         '{{datetime}}': now.strftime('%Y-%m-%d %H:%M:%S'),
+        '{{year}}': now.strftime('%Y'),
+        '{{month}}': now.strftime('%m'),
+        '{{day}}': now.strftime('%d'),
         '{{timestamp}}': str(int(now.timestamp())),
         '{{title}}': note.stem,
         '{{folder}}': note.parent.name if str(note.parent) != '.' else 'Root',

--- a/documentation/TEMPLATES.md
+++ b/documentation/TEMPLATES.md
@@ -37,6 +37,9 @@ Templates support dynamic placeholders that are replaced when you create a note:
 | Placeholder | Description | Example |
 |------------|-------------|---------|
 | `{{date}}` | Current date | `2025-11-26` |
+| `{{year}}` | Current year | `2025` |
+| `{{month}}` | Current month | `11` |
+| `{{day}}` | Current day | `26` |
 | `{{time}}` | Current time | `14:30:45` |
 | `{{datetime}}` | Current date and time | `2025-11-26 14:30:45` |
 | `{{timestamp}}` | Unix timestamp | `1732632645` |


### PR DESCRIPTION
This can be useful when e.g. defining template for a journal, that would automatically link to the month page.

```
{{date}}

---
⬅️ [{{year}}-{{month}}](Journal/{{year}}/{{month}})
```

Although this is how _I_ use these today, through a plugin, I figured it wouldn't hurt to add them to the list of "official" template placeholders.

Happy to hear your thoughts! 