### PR TITLE
Add read-only mode and Windows service support

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -195,6 +195,17 @@ app.add_middleware(
 DEMO_MODE = os.getenv('DEMO_MODE', 'false').lower() in ('true', '1', 'yes')
 ALREADY_DONATED = os.getenv('ALREADY_DONATED', 'false').lower() in ('true', '1', 'yes')
 
+# Read-only mode - blocks all write operations when enabled
+# Set READ_ONLY=true env var or read_only.enabled: true in config.yaml
+_read_only_config = os.getenv('READ_ONLY', '').lower()
+if _read_only_config in ('true', '1', 'yes'):
+    READ_ONLY = True
+elif _read_only_config in ('false', '0', 'no'):
+    READ_ONLY = False
+else:
+    READ_ONLY = config.get('read_only', {}).get('enabled', False)
+print(f"📖 Read-only mode {'ENABLED' if READ_ONLY else 'DISABLED'} ({'READ_ONLY env var' if _read_only_config else 'config.yaml'})")
+
 if DEMO_MODE:
     # Enable rate limiting for demo deployments
     limiter = Limiter(key_func=get_remote_address, default_limits=["200/hour"])
@@ -284,10 +295,16 @@ async def require_auth(request: Request):
     """Dependency to require authentication on protected routes"""
     if not auth_enabled():
         return  # Auth disabled, allow all
-    
+
     if not request.session.get('authenticated'):
         # Always raise exception - route handlers will catch and redirect as needed
         raise HTTPException(status_code=401, detail="Not authenticated")
+
+
+async def require_write_access():
+    """Dependency to block write operations in read-only mode"""
+    if READ_ONLY:
+        raise HTTPException(status_code=403, detail="Read-only mode is enabled")
 
 
 def verify_password(password: str) -> bool:
@@ -365,6 +382,12 @@ api_router = APIRouter(
     dependencies=[Depends(require_auth)]  # Apply auth to ALL routes in this router
 )
 
+# Create write router - requires auth AND blocks requests in read-only mode
+write_router = APIRouter(
+    prefix="/api",
+    dependencies=[Depends(require_auth), Depends(require_write_access)]
+)
+
 # Create pages router with authentication dependency applied globally
 pages_router = APIRouter(
     dependencies=[Depends(require_auth)]  # Apply auth to ALL routes in this router
@@ -384,6 +407,7 @@ async def get_config():
         "searchEnabled": config['search']['enabled'],
         "demoMode": DEMO_MODE,  # Expose demo mode flag to frontend
         "alreadyDonated": ALREADY_DONATED,  # Hide support buttons if true
+        "readOnly": READ_ONLY,  # Expose read-only mode flag to frontend
         "authentication": {
             "enabled": config.get('authentication', {}).get('enabled', False)
         }
@@ -454,7 +478,7 @@ async def get_locale(locale_code: str):
         raise HTTPException(status_code=500, detail=f"Failed to load locale: {str(e)}")
 
 
-@api_router.post("/folders", tags=["Folders"])
+@write_router.post("/folders", tags=["Folders"])
 @limiter.limit("30/minute")
 async def create_new_folder(request: Request, data: dict):
     """Create a new folder"""
@@ -510,7 +534,7 @@ async def get_media(media_path: str):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to load media file"))
 
 
-@api_router.post("/upload-media", tags=["Media"])
+@write_router.post("/upload-media", tags=["Media"])
 @limiter.limit("20/minute")
 async def upload_media(request: Request, file: UploadFile = File(...), note_path: str = Form(...)):
     """
@@ -587,7 +611,7 @@ async def upload_media(request: Request, file: UploadFile = File(...), note_path
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to upload file"))
 
 
-@api_router.post("/media/move", tags=["Media"])
+@write_router.post("/media/move", tags=["Media"])
 @limiter.limit("30/minute")
 async def move_media_endpoint(request: Request, data: dict):
     """Move a media file to a different folder"""
@@ -637,7 +661,7 @@ async def move_media_endpoint(request: Request, data: dict):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to move media file"))
 
 
-@api_router.post("/notes/move", tags=["Notes"])
+@write_router.post("/notes/move", tags=["Notes"])
 @limiter.limit("30/minute")
 async def move_note_endpoint(request: Request, data: dict):
     """Move a note to a different folder"""
@@ -671,7 +695,7 @@ async def move_note_endpoint(request: Request, data: dict):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to move note"))
 
 
-@api_router.post("/folders/move", tags=["Folders"])
+@write_router.post("/folders/move", tags=["Folders"])
 @limiter.limit("20/minute")
 async def move_folder_endpoint(request: Request, data: dict):
     """Move a folder to a different location"""
@@ -699,7 +723,7 @@ async def move_folder_endpoint(request: Request, data: dict):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to move folder"))
 
 
-@api_router.post("/folders/rename", tags=["Folders"])
+@write_router.post("/folders/rename", tags=["Folders"])
 @limiter.limit("30/minute")
 async def rename_folder_endpoint(request: Request, data: dict):
     """Rename a folder"""
@@ -727,7 +751,7 @@ async def rename_folder_endpoint(request: Request, data: dict):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to rename folder"))
 
 
-@api_router.delete("/folders/{folder_path:path}", tags=["Folders"])
+@write_router.delete("/folders/{folder_path:path}", tags=["Folders"])
 @limiter.limit("20/minute")
 async def delete_folder_endpoint(request: Request, folder_path: str):
     """Delete a folder and all its contents"""
@@ -836,7 +860,7 @@ async def get_template(request: Request, template_name: str):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to get template"))
 
 
-@api_router.post("/templates/create-note", tags=["Templates"])
+@write_router.post("/templates/create-note", tags=["Templates"])
 @limiter.limit("60/minute")
 async def create_note_from_template(request: Request, data: dict):
     """
@@ -931,7 +955,7 @@ async def get_note(note_path: str):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to load note"))
 
 
-@api_router.post("/notes/{note_path:path}", tags=["Notes"])
+@write_router.post("/notes/{note_path:path}", tags=["Notes"])
 @limiter.limit("60/minute")
 async def create_or_update_note(request: Request, note_path: str, content: dict):
     """Create or update a note"""
@@ -972,7 +996,7 @@ async def create_or_update_note(request: Request, note_path: str, content: dict)
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to save note"))
 
 
-@api_router.delete("/notes/{note_path:path}", tags=["Notes"])
+@write_router.delete("/notes/{note_path:path}", tags=["Notes"])
 @limiter.limit("30/minute")
 async def remove_note(request: Request, note_path: str):
     """Delete a note"""
@@ -1180,7 +1204,7 @@ async def calculate_note_stats(content: str):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to calculate note statistics"))
 
 
-@api_router.post("/plugins/{plugin_name}/toggle", tags=["Plugins"])
+@write_router.post("/plugins/{plugin_name}/toggle", tags=["Plugins"])
 @limiter.limit("10/minute")
 async def toggle_plugin(request: Request, plugin_name: str, enabled: dict):
     """Enable or disable a plugin"""
@@ -1204,7 +1228,7 @@ async def toggle_plugin(request: Request, plugin_name: str, enabled: dict):
 # Share Token Endpoints (authenticated)
 # ============================================================================
 
-@api_router.post("/share/{note_path:path}", tags=["Sharing"])
+@write_router.post("/share/{note_path:path}", tags=["Sharing"])
 @limiter.limit("30/minute")
 async def create_share(request: Request, note_path: str, data: dict = None):
     """
@@ -1292,7 +1316,7 @@ async def list_shared_notes(request: Request):
         raise HTTPException(status_code=500, detail=safe_error_message(e, "Failed to get shared notes"))
 
 
-@api_router.delete("/share/{note_path:path}", tags=["Sharing"])
+@write_router.delete("/share/{note_path:path}", tags=["Sharing"])
 @limiter.limit("30/minute")
 async def delete_share(request: Request, note_path: str):
     """
@@ -1429,6 +1453,7 @@ async def catch_all(full_path: str, request: Request):
 # Register routers with the main app
 # Authentication is applied via router dependencies
 app.include_router(api_router)
+app.include_router(write_router)
 app.include_router(pages_router)
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,11 @@ storage:
 search:
   enabled: true
   
+read_only:
+  # Read-only mode - prevents all write operations (create, edit, delete, upload)
+  # Can also be set via READ_ONLY environment variable
+  enabled: false
+
 authentication:
   # Authentication settings
   # Set enabled to true to require login

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -145,6 +145,7 @@ function noteApp() {
         appVersion: '0.0.0',
         authEnabled: false,
         demoMode: false,
+        readOnly: false,
         alreadyDonated: false,
         notes: [],
         currentNote: '',
@@ -711,7 +712,11 @@ function noteApp() {
                 this.appVersion = config.version || '0.0.0';
                 this.authEnabled = config.authentication?.enabled || false;
                 this.demoMode = config.demoMode || false;
+                this.readOnly = config.readOnly || false;
                 this.alreadyDonated = config.alreadyDonated || false;
+                if (this.readOnly) {
+                    this.viewMode = 'preview';
+                }
             } catch (error) {
                 console.error('Failed to load config:', error);
             }
@@ -2173,7 +2178,8 @@ function noteApp() {
         async onEditorDrop(event) {
             event.preventDefault();
             this.dropTarget = null;
-            
+            if (this.readOnly) return;
+
             // Check if files are being dropped (media from file system)
             if (event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files.length > 0) {
                 await this.handleMediaDrop(event);
@@ -2320,6 +2326,7 @@ function noteApp() {
         // Handle paste event for clipboard media (images)
         async handlePaste(event) {
             if (!this.currentNote) return;
+            if (this.readOnly) return;
             
             const items = event.clipboardData?.items;
             if (!items) return;
@@ -5519,6 +5526,7 @@ function noteApp() {
         
         // Toggle Zen Mode (full immersive writing experience)
         async toggleZenMode() {
+            if (this.readOnly) return;
             if (!this.zenMode) {
                 // Entering Zen Mode
                 this.previousViewMode = this.viewMode;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1426,7 +1426,8 @@
                     <!-- Header with + New -->
                     <div class="flex-shrink-0 px-2 py-2 border-b flex items-center justify-between" style="border-color: var(--border-primary);">
                         <span class="text-xs font-semibold uppercase tracking-wide" style="color: var(--text-tertiary);" x-text="t('sidebar.files')"></span>
-                <button 
+                <button
+                    x-show="!readOnly"
                     @click="dropdownTargetFolder = ''; toggleNewDropdown($event)"
                             class="px-2 py-1 text-xs font-medium text-white rounded focus:outline-none flex items-center gap-1"
                     style="background-color: var(--accent-primary);"
@@ -2005,7 +2006,8 @@
                         </svg>
                             <h2 class="text-2xl font-bold mb-2" style="color: var(--text-primary);" x-text="t('homepage.no_notes_title')"></h2>
                             <p class="mb-6" style="color: var(--text-secondary);" x-text="t('homepage.no_notes_desc')"></p>
-                        <button 
+                        <button
+                                x-show="!readOnly"
                                 @click="dropdownTargetFolder = selectedHomepageFolder; toggleNewDropdown($event)"
                                 class="px-6 py-3 text-sm font-medium text-white rounded-lg transition-colors"
                             style="background-color: var(--accent-primary);"
@@ -2066,7 +2068,8 @@
                                             <span x-text="homepageFolders().length"></span> 
                                             <span x-text="homepageFolders().length === 1 ? t('homepage.folder_singular') : t('homepage.folder_plural')"></span>
                                         </span>
-                                        <button 
+                                        <button
+                                            x-show="!readOnly"
                                             @click="dropdownTargetFolder = selectedHomepageFolder; toggleNewDropdown($event)"
                                             class="ml-auto px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors"
                                             style="background-color: var(--accent-primary);"
@@ -2087,7 +2090,8 @@
                                     </svg>
                                     <h2 class="text-2xl font-bold mb-2" style="color: var(--text-primary);" x-text="selectedHomepageFolder ? t('homepage.folder_empty') : t('homepage.no_notes_title')"></h2>
                                     <p class="mb-6" style="color: var(--text-secondary);" x-text="selectedHomepageFolder ? t('homepage.get_started') : t('homepage.no_notes_desc')"></p>
-                                    <button 
+                                    <button
+                                        x-show="!readOnly"
                                         @click="dropdownTargetFolder = selectedHomepageFolder; toggleNewDropdown($event)"
                                         class="px-6 py-3 text-sm font-medium text-white rounded-lg transition-colors"
                                         style="background-color: var(--accent-primary);"
@@ -2112,7 +2116,8 @@
                                             onmouseout="this.style.borderColor='var(--accent-primary)'; this.style.transform='translateY(0)'; this.querySelector('.card-delete-btn').style.opacity='0';"
                                         >
                                             <!-- Delete Button -->
-                                            <button 
+                                            <button
+                                                x-show="!readOnly"
                                                 @click.stop="deleteFolder(folder.path, folder.name)"
                                                 class="card-delete-btn hidden sm:block"
                                                 style="position: absolute; top: 8px; right: 8px; opacity: 0; transition: opacity 0.2s; color: var(--error); padding: 4px; border-radius: 4px; background-color: var(--bg-secondary);"
@@ -2153,7 +2158,8 @@
                                             onmouseout="this.style.borderColor='var(--border-primary)'; this.style.transform='translateY(0)'; this.querySelector('.card-delete-btn').style.opacity='0';"
                                         >
                                             <!-- Delete Button -->
-                                            <button 
+                                            <button
+                                                x-show="!readOnly"
                                                 @click.stop="note.type !== 'note' ? deleteMedia(note.path) : deleteNote(note.path, note.name)"
                                                 class="card-delete-btn hidden sm:block"
                                                 style="position: absolute; top: 8px; right: 8px; opacity: 0; transition: opacity 0.2s; color: var(--error); padding: 4px; border-radius: 4px; background-color: var(--bg-secondary);"
@@ -2249,7 +2255,8 @@
                             </button>
                             
                             <!-- Delete Button -->
-                            <button 
+                            <button
+                                x-show="!readOnly"
                                 @click="currentMedia ? deleteMedia(currentMedia) : deleteCurrentNote()"
                                 class="p-2 rounded-lg"
                                 style="color: var(--error);"
@@ -2277,7 +2284,8 @@
                         <div class="flex items-center space-x-2" x-show="currentNote">
                             <!-- View Toggle (only for notes) -->
                             <div class="flex rounded-lg p-1" style="background-color: var(--bg-tertiary);">
-                                <button 
+                                <button
+                                    x-show="!readOnly"
                                     @click="viewMode = 'edit'"
                                     class="px-2 md:px-3 py-1 text-xs md:text-sm rounded transition"
                                     :style="viewMode === 'edit' ? 'background-color: var(--accent-primary); color: white;' : 'color: var(--text-secondary);'"
@@ -2286,7 +2294,8 @@
                                     x-text="t('editor.mode_edit')"
                                 >
                                 </button>
-                                <button 
+                                <button
+                                    x-show="!readOnly"
                                     @click="viewMode = 'split'"
                                     class="mobile-hide-split px-2 md:px-3 py-1 text-xs md:text-sm rounded transition"
                                     :style="viewMode === 'split' ? 'background-color: var(--accent-primary); color: white;' : 'color: var(--text-secondary);'"
@@ -2376,7 +2385,8 @@
                                     </svg>
                                 </button>
                                 <div style="width: 1px; height: 20px; background-color: var(--border-primary);"></div>
-                                <button 
+                                <button
+                                    x-show="!readOnly"
                                     @click="toggleZenMode()"
                                     class="p-2 transition"
                                     style="color: var(--text-secondary);"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ bcrypt==4.1.2
 itsdangerous==2.1.2
 slowapi==0.1.9
 colorama==0.4.6
+pywin32==306
+psutil==5.9.8

--- a/run.py
+++ b/run.py
@@ -39,6 +39,10 @@ def get_port():
 def main():
     print("🚀 Starting NoteDiscovery...\n")
     
+    # Detect if running as Windows Service
+    is_service = 'pythonservice.exe' in sys.executable.lower() or \
+                 os.environ.get('RUNNING_AS_SERVICE') == '1'
+    
     # Check if requirements are installed
     try:
         import fastapi
@@ -56,26 +60,36 @@ def main():
     
     print("✓ Dependencies installed")
     print("✓ Directories created")
-    print("\n" + "="*50)
-    print("🎉 NoteDiscovery is running!")
-    print("="*50)
-    print(f"\n📝 Open your browser to: http://localhost:{port}")
-    print("\n💡 Tips:")
-    print("   - Press Ctrl+C to stop the server")
-    print("   - Your notes are in ./data/")
-    print("   - Plugins go in ./plugins/")
-    print(f"   - Change port with: PORT={port} python run.py")
-    print("\n" + "="*50 + "\n")
+    
+    if not is_service:
+        print("\n" + "="*50)
+        print("🎉 NoteDiscovery is running!")
+        print("="*50)
+        print(f"\n📝 Open your browser to: http://localhost:{port}")
+        print("\n💡 Tips:")
+        print("   - Press Ctrl+C to stop the server")
+        print("   - Your notes are in ./data/")
+        print("   - Plugins go in ./plugins/")
+        print(f"   - Change port with: PORT={port} python run.py")
+        print("\n" + "="*50 + "\n")
+    else:
+        print(f"Starting NoteDiscovery as Windows Service on port {port}")
     
     # Run the application
-    subprocess.call([
+    # Disable --reload when running as service (it doesn't work in service context)
+    uvicorn_args = [
         sys.executable, "-m", "uvicorn",
         "backend.main:app",
-        "--reload",
         "--host", "0.0.0.0",
         "--port", port,
         "--timeout-graceful-shutdown", "2"
-    ])
+    ]
+    
+    if not is_service:
+        uvicorn_args.insert(4, "--reload")  # Insert after "backend.main:app"
+    
+    print(f"Starting uvicorn with args: {' '.join(uvicorn_args[2:])}")
+    subprocess.call(uvicorn_args)
 
 if __name__ == "__main__":
     main()

--- a/run_service.py
+++ b/run_service.py
@@ -1,0 +1,180 @@
+# cd notediscovery installation path
+# pip install pywin32
+# pip install psutil 
+
+# python .\run_service.py install
+# python .\run_service.py remove
+# python .\run_service.py start
+# python .\run_service.py stop
+
+import win32serviceutil
+import win32service
+import win32event
+import servicemanager
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+class PyService(win32serviceutil.ServiceFramework):
+    _svc_name_ = "NoteDiscovery"
+    _svc_display_name_ = "NoteDiscovery Service"
+    _svc_description_ = "Start NoteDiscovery - 127.0.0.1:8000" #check your port
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.stop_event = win32event.CreateEvent(None, 0, 0, None)
+        self.process = None
+        
+        # Setup paths
+        self.service_dir = Path(__file__).parent.absolute()
+        self.log_file = self.service_dir / "service.log"
+        self.error_file = self.service_dir / "service_error.log"
+
+    def log(self, message):
+        """Write to both service log and file"""
+        # Windows Event Log
+        servicemanager.LogInfoMsg(f"{self._svc_name_}: {message}")
+        # File log
+        try:
+            with open(self.log_file, 'a', encoding='utf-8') as f:
+                from datetime import datetime
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                f.write(f"[{timestamp}] {message}\n")
+        except Exception:
+            pass
+
+    def SvcStop(self):
+        self.log("Stop signal received")
+        self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
+        if self.process and self.process.poll() is None:
+            try:
+                self.log("Terminating process tree...")
+                # Kill the entire process tree (including child processes like uvicorn)
+                self._kill_process_tree(self.process.pid)
+                self.log("Process tree terminated successfully")
+            except Exception as e:
+                self.log(f"Error terminating process: {e}")
+        win32event.SetEvent(self.stop_event)
+
+    def _kill_process_tree(self, pid):
+        """Terminate a process and all its children"""
+        import psutil
+        try:
+            parent = psutil.Process(pid)
+            children = parent.children(recursive=True)
+            
+            # Terminate children first
+            for child in children:
+                try:
+                    self.log(f"Terminating child process {child.pid}")
+                    child.terminate()
+                except psutil.NoSuchProcess:
+                    pass
+            
+            # Terminate parent
+            parent.terminate()
+            
+            # Wait for graceful termination
+            gone, alive = psutil.wait_procs(children + [parent], timeout=5)
+            
+            # Force kill any remaining processes
+            for p in alive:
+                try:
+                    self.log(f"Force killing process {p.pid}")
+                    p.kill()
+                except psutil.NoSuchProcess:
+                    pass
+                    
+        except psutil.NoSuchProcess:
+            self.log(f"Process {pid} already terminated")
+        except Exception as e:
+            self.log(f"Error in _kill_process_tree: {e}")
+
+    def SvcDoRun(self):
+        try:
+            self.log(f"Service starting in directory: {self.service_dir}")
+            servicemanager.LogMsg(servicemanager.EVENTLOG_INFORMATION_TYPE,
+                                  servicemanager.PYS_SERVICE_STARTED,
+                                  (self._svc_name_, ''))
+            
+            # In service context, sys.executable is pythonservice.exe, not python.exe
+            # We need to find the actual python.exe in the same directory
+            service_exe = Path(sys.executable)
+            python_exe = service_exe.parent / "python.exe"
+            
+            if not python_exe.exists():
+                # Try pythonw.exe as fallback
+                python_exe = service_exe.parent / "pythonw.exe"
+            
+            if not python_exe.exists():
+                self.log(f"ERROR: Could not find python.exe in {service_exe.parent}")
+                return
+            
+            script_path = self.service_dir / "run.py"
+            
+            self.log(f"Python executable: {python_exe}")
+            self.log(f"Script path: {script_path}")
+            
+            # Check if script exists
+            if not script_path.exists():
+                self.log(f"ERROR: Script not found at {script_path}")
+                return
+            
+            # Create/clear log files (use 'w' to overwrite old logs)
+            stdout_file = open(self.service_dir / "service_stdout.log", 'w', encoding='utf-8')
+            stderr_file = open(self.service_dir / "service_stderr.log", 'w', encoding='utf-8')
+            
+            self.log("Log files created/cleared")
+            
+            # Prepare environment with service flag
+            env = os.environ.copy()
+            env['RUNNING_AS_SERVICE'] = '1'
+            env['PYTHONIOENCODING'] = 'utf-8'  # Fix emoji encoding issues
+            env['PYTHONUTF8'] = '1'  # Enable UTF-8 mode
+            
+            # Start subprocess with proper working directory and output redirection
+            self.log("Starting subprocess...")
+            self.process = subprocess.Popen(
+                [str(python_exe), str(script_path)],
+                cwd=str(self.service_dir),
+                stdout=stdout_file,
+                stderr=stderr_file,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+                env=env
+            )
+            
+            self.log(f"Process started with PID: {self.process.pid}")
+            
+            # Check if process is still running after a short delay
+            import time
+            time.sleep(2)
+            if self.process.poll() is not None:
+                self.log(f"WARNING: Process terminated immediately with code: {self.process.returncode}")
+                stdout_file.close()
+                stderr_file.close()
+                return
+            else:
+                self.log("Process is running successfully")
+            
+            # Wait until stop requested
+            win32event.WaitForSingleObject(self.stop_event, win32event.INFINITE)
+            
+            # Cleanup
+            self.log("Cleaning up...")
+            stdout_file.close()
+            stderr_file.close()
+            
+            if self.process and self.process.poll() is None:
+                try:
+                    self._kill_process_tree(self.process.pid)
+                except Exception as e:
+                    self.log(f"Error during cleanup: {e}")
+                    
+        except Exception as e:
+            self.log(f"EXCEPTION in SvcDoRun: {e}")
+            import traceback
+            self.log(traceback.format_exc())
+
+if __name__ == '__main__':
+    win32serviceutil.HandleCommandLine(PyService)


### PR DESCRIPTION
## Summary

- **Read-only mode**: Adds a READ_ONLY flag (via env var or config.yaml) that blocks all write operations. A dedicated write_router uses a require_write_access dependency to return HTTP 403 on any create/edit/delete/upload endpoint when active. The flag is exposed to the frontend, which hides all edit/delete/create buttons and locks the editor to preview mode.
- **Windows Service**: Adds run_service.py to run NoteDiscovery as a Windows Service using pywin32. Supports install, start, stop, remove commands.
- **Service-aware startup**: run.py detects when running as a Windows Service and disables --reload and console output accordingly.
- **Dependencies**: pywin32 and psutil added to requirements.txt.

## Test plan

- [ ] Start app normally -- verify read-only mode is off by default (config.yaml: enabled: false)
- [ ] Set READ_ONLY=true env var or read_only.enabled: true in config.yaml -- verify all write endpoints return 403
- [ ] Verify frontend hides New/Delete/Edit buttons and opens notes in preview mode when read-only
- [ ] On Windows: python run_service.py install + start -- verify service starts and NoteDiscovery is reachable
- [ ] On Windows: python run_service.py stop + remove -- verify clean shutdown
