### PR TITLE
Updated hu-HU.json

### DIFF
--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -252,8 +252,8 @@
     "readable_line_length_desc": "Korlátozd az előnézeti szélességet a könnyebb olvasás érdekében",
     "hide_underscore_folders": "Rendszermappák elrejtése",
     "hide_underscore_folders_desc": "_attachments, _templates és más aláhúzásos mappák elrejtése",
-    "tab_inserts_tab": "Tab billentyű tabulátort szúr be",
-    "tab_inserts_tab_desc": "Nyomja meg a Tab-ot tabulátor beszúrásához a fókuszváltás helyett"
+    "tab_inserts_tab": "Tab billentyű több helyet hagy a szövegben",
+    "tab_inserts_tab_desc": "Nyomd meg a Tab-ot, hogy több helyet hagyj a szövegben a fókuszváltás helyett"
   },
 
   "homepage": {


### PR DESCRIPTION
I found 'tabulátor' too technical, so instead I chose 'több helyet hagy' (leaves more space). 

The goal was to make the concept instantly clear for non-technical users or those unfamiliar with what 'tab' does.  
This way, it's simple, visual, and understandable. 😃