### PR TITLE
Fix create_note_from_template MCP tool: post templateName/notePath

### DIFF
--- a/mcp_server/client.py
+++ b/mcp_server/client.py
@@ -254,9 +254,10 @@ class NoteDiscoveryClient:
         Returns:
             APIResponse with creation result
         """
+        # The /api/templates/create-note endpoint reads `templateName` and `notePath`.
         data = {
-            "template": template_name,
-            "path": note_path,
+            "templateName": template_name,
+            "notePath": note_path,
         }
         if variables:
             data["variables"] = variables


### PR DESCRIPTION
The `create_note_from_template` MCP tool fails on every call with `HTTP 400: Template name and note path required`.

## Cause

The MCP client posts the wrong JSON keys to `/api/templates/create-note`. It sends `template` and `path`:

```python
# mcp_server/client.py
data = {
    "template": template_name,
    "path": note_path,
}
```

but the endpoint reads `templateName` and `notePath`:

```python
# backend/main.py  (POST /api/templates/create-note)
template_name = data.get('templateName', '')
note_path = data.get('notePath', '')

if not template_name or not note_path:
    raise HTTPException(status_code=400, detail="Template name and note path required")
```

Both values arrive empty, so the request is rejected before the template is ever loaded.

## Reproduce

1. Drop a template in `data/_templates/`, e.g. `daily.md`.
2. Call the MCP tool `create_note_from_template` with `template_name="daily"`, `note_path="test.md"`.
3. Result: `HTTP 400: Template name and note path required`.

Posting the same body to the HTTP endpoint directly with the correct keys (`templateName`/`notePath`) succeeds, which confirms the backend is fine and the mismatch is purely client-side.

## Fix

Send the keys the endpoint expects:

```python
data = {
    "templateName": template_name,
    "notePath": note_path,
}
```

One-line change in `mcp_server/client.py`. After it, the tool creates the note and the built-in placeholders (`{{title}}`, `{{date}}`, `{{datetime}}`, …) are substituted as documented.

## Side note (left out of this PR on purpose)

The client also sends `variables` in the payload, but the endpoint never reads it — `apply_template_placeholders` only substitutes the built-in date/title/folder placeholders. So custom `variables` passed through the MCP tool are silently dropped. I kept this PR to the single key-name fix, but it's probably worth either threading `variables` into `apply_template_placeholders` or removing the parameter from the tool schema so the API doesn't advertise something the server ignores. Happy to do that as a follow-up if you'd like.
