### PR TITLE
Feature/drag drop md files

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -249,6 +249,7 @@ UPLOAD_MAX_IMAGE_MB = int(os.getenv('UPLOAD_MAX_IMAGE_MB', '10'))
 UPLOAD_MAX_AUDIO_MB = int(os.getenv('UPLOAD_MAX_AUDIO_MB', '50'))
 UPLOAD_MAX_VIDEO_MB = int(os.getenv('UPLOAD_MAX_VIDEO_MB', '100'))
 UPLOAD_MAX_PDF_MB = int(os.getenv('UPLOAD_MAX_PDF_MB', '20'))
+UPLOAD_MAX_NOTE_MB = int(os.getenv('UPLOAD_MAX_NOTE_MB', '10'))
 
 # Autosave debounce in milliseconds (applies to note typing AND drawing PNG autosave).
 try:
@@ -549,6 +550,7 @@ async def get_config():
         "alreadyDonated": ALREADY_DONATED,  # Hide support buttons if true
         "autosaveDelayMs": AUTOSAVE_DELAY_MS,  # Debounce for note/drawing autosave
         "defaultTheme": DEFAULT_THEME,  # Used when the browser has no saved preference
+        "uploadMaxNoteMb": UPLOAD_MAX_NOTE_MB,  # Client-side size cap for .md drops
         "authentication": {
             "enabled": config.get('authentication', {}).get('enabled', False)
         }

--- a/documentation/ENVIRONMENT_VARIABLES.md
+++ b/documentation/ENVIRONMENT_VARIABLES.md
@@ -79,6 +79,7 @@ AUTHENTICATION_PASSWORD=mysecretpassword
 | `UPLOAD_MAX_AUDIO_MB` | integer | `50` | Maximum audio upload size in MB |
 | `UPLOAD_MAX_VIDEO_MB` | integer | `100` | Maximum video upload size in MB |
 | `UPLOAD_MAX_PDF_MB` | integer | `20` | Maximum PDF upload size in MB |
+| `UPLOAD_MAX_NOTE_MB` | integer | `10` | Maximum size of `.md` files imported via drag & drop |
 
 #### Example: Allowing larger video uploads
 

--- a/documentation/FEATURES.md
+++ b/documentation/FEATURES.md
@@ -18,7 +18,7 @@
 
 ### Media Support
 - **Drawing editor** — In-app **`drawing-*.png`** sketches next to your notes ([overview](#drawing-editor)); full guide: **[DRAWING.md](DRAWING.md)**
-- **Drag & drop upload** - Drop files from your file system directly into the editor
+- **Drag & drop upload** - Drop files from your file system into the editor: images/audio/video/PDF go to `_attachments`; `.md` files land next to the current note and get an inline link at the drop point
 - **Clipboard paste** - Paste images from clipboard with Ctrl+V
 - **Images** - JPG, PNG, GIF, WebP (default max 10MB, configurable)
 - **Audio** - MP3, WAV, OGG, M4A (default max 50MB, configurable)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,6 +4,7 @@
 const CONFIG = {
     AUTOSAVE_DELAY: 1000,              // ms - Fallback only; runtime value lives on this.autosaveDelayMs (hydrated from /api/config). Used by autoSave() and _drawingScheduleAutosave().
     DEFAULT_THEME: 'light',            // Fallback only; runtime value lives on this.defaultTheme (hydrated from /api/config). Used by initTheme() when localStorage has no saved preference.
+    UPLOAD_MAX_NOTE_MB: 10,            // MB - Fallback only; runtime value lives on this.uploadMaxNoteMb (hydrated from /api/config). Used by importMarkdownFile() to cap drag-drop .md imports.
     /** Must match drawingRedraw() fill and eraser stroke color (opaque “whiteboard”). */
     DRAWING_BACKGROUND: '#ffffff',
     /**
@@ -265,6 +266,7 @@ function noteApp() {
         alreadyDonated: false,
         autosaveDelayMs: CONFIG.AUTOSAVE_DELAY,  // hydrated from /api/config in loadConfig()
         defaultTheme: CONFIG.DEFAULT_THEME,      // hydrated from /api/config in loadConfig()
+        uploadMaxNoteMb: CONFIG.UPLOAD_MAX_NOTE_MB, // hydrated from /api/config in loadConfig()
         notes: [],
 
         // True while /api/notes is in flight. Drives the "Loading your vault…"
@@ -1015,6 +1017,9 @@ function noteApp() {
                 }
                 if (typeof config.defaultTheme === 'string' && config.defaultTheme) {
                     this.defaultTheme = config.defaultTheme;
+                }
+                if (Number.isFinite(config.uploadMaxNoteMb) && config.uploadMaxNoteMb > 0) {
+                    this.uploadMaxNoteMb = config.uploadMaxNoteMb;
                 }
             } catch (error) {
                 console.error('Failed to load config:', error);
@@ -2984,14 +2989,16 @@ function noteApp() {
          * currently open note, then insert a standard `[Name](path)` link at
          * cursorPos (same link shape as sidebar note drops). On filename
          * collision, appends a yyyymmddHHmmss suffix (matches drawing PNGs).
-         * A defensive 10 MB size cap avoids accidental huge-file drops; normal
-         * markdown notes are orders of magnitude smaller.
+         * Size cap comes from UPLOAD_MAX_NOTE_MB (env-configurable via
+         * /api/config); guards against accidental huge-file drops that would
+         * OOM the browser during file.text().
          */
         async importMarkdownFile(file, cursorPos) {
             if (!this.currentNote) return;
             
-            const MAX_MD_BYTES = 10 * 1024 * 1024;
-            if (file.size > MAX_MD_BYTES) {
+            const maxBytes = this.uploadMaxNoteMb * 1024 * 1024;
+            if (file.size > maxBytes) {
+                console.warn(`Rejected markdown drop: ${file.name} is ${(file.size / 1024 / 1024).toFixed(2)}MB, limit is ${this.uploadMaxNoteMb}MB (UPLOAD_MAX_NOTE_MB).`);
                 this.toast(this.t('media.upload_failed'), { type: 'warning' });
                 return;
             }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -173,6 +173,8 @@ const FilenameValidator = {
 /** Max leading spaces Shift+Tab removes per line when matching one “tab indent” vs \t inserts. */
 const EDITOR_TAB_OUTDENT_MAX_SPACES = 4;
 
+const MEDIA_FORMATS_DISPLAY = 'JPG, PNG, GIF, WebP, MP3, MP4, PDF, MD';
+
 function editorIndentRemoveLen(lineSegment) {
     if (!lineSegment || lineSegment.length === 0) return 0;
     if (lineSegment.charCodeAt(0) === 9 /* \t */) return 1;
@@ -2931,9 +2933,13 @@ function noteApp() {
                 'application/pdf'
             ];
             const mediaFiles = files.filter(file => allowedTypes.includes(file.type.toLowerCase()));
+            // Detect markdown by extension — MIME reporting for .md is inconsistent
+            // across browsers/OSes (text/markdown, text/plain, or empty), so name
+            // is the only reliable signal.
+            const markdownFiles = files.filter(file => /\.md$/i.test(file.name || ''));
             
-            if (mediaFiles.length === 0) {
-                this.toast(this.t('media.no_valid_files'), { type: 'warning' });
+            if (mediaFiles.length === 0 && markdownFiles.length === 0) {
+                this.toast(this.t('media.no_valid_files', { formats: MEDIA_FORMATS_DISPLAY }), { type: 'warning' });
                 return;
             }
             
@@ -2957,6 +2963,85 @@ function noteApp() {
                 }
             }
             // uploadMedia already injects the file into this.notes optimistically.
+            
+            // Markdown drops only make sense when a note is open — the imported
+            // file is placed alongside the current note and a link is inserted
+            // at the drop point. Without a currentNote, silently skip (drops
+            // outside the editor already fall back to the browser default).
+            if (markdownFiles.length > 0 && this.currentNote) {
+                for (const file of markdownFiles) {
+                    try {
+                        await this.importMarkdownFile(file, cursorPos);
+                    } catch (error) {
+                        ErrorHandler.handle(`import markdown ${file.name}`, error);
+                    }
+                }
+            }
+        },
+        
+        /**
+         * Import a dropped .md file as a new note in the same folder as the
+         * currently open note, then insert a standard `[Name](path)` link at
+         * cursorPos (same link shape as sidebar note drops). On filename
+         * collision, appends a yyyymmddHHmmss suffix (matches drawing PNGs).
+         * A defensive 10 MB size cap avoids accidental huge-file drops; normal
+         * markdown notes are orders of magnitude smaller.
+         */
+        async importMarkdownFile(file, cursorPos) {
+            if (!this.currentNote) return;
+            
+            const MAX_MD_BYTES = 10 * 1024 * 1024;
+            if (file.size > MAX_MD_BYTES) {
+                this.toast(this.t('media.upload_failed'), { type: 'warning' });
+                return;
+            }
+            
+            const rawStem = (file.name || '').replace(/\.md$/i, '').trim();
+            const validation = FilenameValidator.validateFilename(rawStem);
+            if (!validation.valid) {
+                this.toast(this.getValidationErrorMessage(validation, 'note'), { type: 'warning' });
+                return;
+            }
+            const stem = validation.sanitized;
+            
+            const currentFolder = this.currentNote.includes('/')
+                ? this.currentNote.substring(0, this.currentNote.lastIndexOf('/'))
+                : '';
+            
+            const joinPath = (folder, filename) => folder ? `${folder}/${filename}` : filename;
+            let targetPath = joinPath(currentFolder, `${stem}.md`);
+            if (this.notes.some(n => n.path === targetPath)) {
+                const ts = this._autoTitleTimestamp();
+                targetPath = joinPath(currentFolder, `${stem}-${ts}.md`);
+            }
+            
+            const content = await file.text();
+            
+            this._optimisticAddNote(targetPath, { content });
+            if (currentFolder) this.expandedFolders.add(currentFolder);
+            this._rebuildTreeAfterMutation();
+            
+            try {
+                const response = await fetch(`/api/notes/${targetPath}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ content })
+                });
+                if (!response.ok) throw new Error('Server returned error');
+            } catch (error) {
+                this._optimisticRemoveNote(targetPath);
+                this._rebuildTreeAfterMutation();
+                throw error;
+            }
+            
+            const noteName = targetPath.split('/').pop().replace(/\.md$/i, '');
+            const encodedPath = targetPath.split('/').map(seg => encodeURIComponent(seg)).join('/');
+            const link = `[${noteName}](${encodedPath})`;
+            
+            const textBefore = this.noteContent.substring(0, cursorPos);
+            const textAfter = this.noteContent.substring(cursorPos);
+            this.noteContent = textBefore + link + '\n' + textAfter;
+            this.autoSave();
         },
         
         // Upload a media file (image, audio, video, PDF)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -384,6 +384,7 @@ function noteApp() {
         // Unified drag state for notes, folders, and media
         draggedItem: null,  // { path: string, type: 'note' | 'folder' | 'image' | 'audio' | 'video' | 'document' }
         dropTarget: null,   // 'editor' | 'folder' | null
+        externalDragActive: false,  // true while OS files (not sidebar items) are being dragged over the editor
         
         // Undo/Redo history
         undoHistory: [],
@@ -2788,10 +2789,15 @@ function noteApp() {
         
         // Handle dragover on editor to show cursor position
         onEditorDragOver(event) {
-            if (!this.draggedItem) return;
+            // Two drag sources land here: internal sidebar items (draggedItem set)
+            // and OS files (dataTransfer.types includes 'Files'). Both should
+            // show the drop affordance and position the caret at the mouse.
+            const isFileDrag = event.dataTransfer?.types?.includes('Files');
+            if (!this.draggedItem && !isFileDrag) return;
             
             event.preventDefault();
             this.dropTarget = 'editor';
+            if (isFileDrag) this.externalDragActive = true;
             
             // Focus the textarea
             const textarea = event.target;
@@ -2843,9 +2849,11 @@ function noteApp() {
         
         // Handle dragenter on editor
         onEditorDragEnter(event) {
-            if (!this.draggedItem) return;
+            const isFileDrag = event.dataTransfer?.types?.includes('Files');
+            if (!this.draggedItem && !isFileDrag) return;
             event.preventDefault();
             this.dropTarget = 'editor';
+            if (isFileDrag) this.externalDragActive = true;
         },
         
         // Handle dragleave on editor
@@ -2854,6 +2862,7 @@ function noteApp() {
             // (not just moving between child elements)
             if (event.target.tagName === 'TEXTAREA') {
                 this.dropTarget = null;
+                this.externalDragActive = false;
             }
         },
         
@@ -2861,6 +2870,7 @@ function noteApp() {
         async onEditorDrop(event) {
             event.preventDefault();
             this.dropTarget = null;
+            this.externalDragActive = false;
             
             // Check if files are being dropped (media from file system)
             if (event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files.length > 0) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3137,9 +3137,9 @@
                                     @dragenter="onEditorDragEnter($event)"
                                     @dragleave="onEditorDragLeave($event)"
                                     @paste="handlePaste($event)"
-                                    :class="'flex-1 w-full resize-none focus:outline-none editor-textarea' + (draggedItem && dropTarget === 'editor' ? ' link-drop-target' : '')"
-                                    :style="'background-color: var(--bg-primary); color: var(--text-primary);' + (draggedItem && dropTarget === 'editor' ? ' outline: 2px dashed var(--accent-primary); outline-offset: -2px; box-shadow: 0 0 20px var(--accent-light);' : '')"
-                                    :placeholder="draggedItem && dropTarget === 'editor' ? t('editor.drop_hint') : t('editor.placeholder')"
+                                    :class="'flex-1 w-full resize-none focus:outline-none editor-textarea' + ((draggedItem || externalDragActive) && dropTarget === 'editor' ? ' link-drop-target' : '')"
+                                    :style="'background-color: var(--bg-primary); color: var(--text-primary);' + ((draggedItem || externalDragActive) && dropTarget === 'editor' ? ' outline: 2px dashed var(--accent-primary); outline-offset: -2px; box-shadow: 0 0 20px var(--accent-light);' : '')"
+                                    :placeholder="(draggedItem || externalDragActive) && dropTarget === 'editor' ? t('editor.drop_hint') : t('editor.placeholder')"
                                 ></textarea>
                             </div>
                         </div>

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -232,8 +232,7 @@
   "media": {
     "confirm_delete": "\"{{name}}\" löschen?",
     "upload_failed": "Datei-Upload fehlgeschlagen",
-    "no_valid_files": "Keine gültigen Dateien gefunden. Unterstützt: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "Keine gültigen Dateien gefunden. Unterstützt: {{formats}}"
   },
   "move": {
     "failed_note": "Verschieben der Notiz fehlgeschlagen.",

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -231,8 +231,7 @@
   "media": {
     "confirm_delete": "Delete \"{{name}}\"?",
     "upload_failed": "Failed to upload file",
-    "no_valid_files": "No valid files found. Supported: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "No valid files found. Supported: {{formats}}"
   },
   "move": {
     "failed_note": "Failed to move note.",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -232,8 +232,7 @@
   "media": {
     "confirm_delete": "Delete \"{{name}}\"?",
     "upload_failed": "Failed to upload file",
-    "no_valid_files": "No valid files found. Supported: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "No valid files found. Supported: {{formats}}"
   },
   "move": {
     "failed_note": "Failed to move note.",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -232,8 +232,7 @@
   "media": {
     "confirm_delete": "¿Eliminar \"{{name}}\"?",
     "upload_failed": "Error al subir archivo",
-    "no_valid_files": "No se encontraron archivos válidos. Soporta: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "No se encontraron archivos válidos. Soporta: {{formats}}"
   },
   "move": {
     "failed_note": "Error al mover la nota.",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -232,8 +232,7 @@
   "media": {
     "confirm_delete": "Supprimer \"{{name}}\" ?",
     "upload_failed": "Échec du téléchargement du fichier",
-    "no_valid_files": "Aucun fichier valide trouvé. Supporté : JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "Aucun fichier valide trouvé. Supporté : {{formats}}"
   },
   "move": {
     "failed_note": "Échec du déplacement de la note.",

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -232,8 +232,7 @@
   "media": {
     "confirm_delete": "Biztos törlöd a következőt:  \"{{name}}\"?",
     "upload_failed": "Hiba a fájl feltöltése során",
-    "no_valid_files": "Nem található érvényes fájl. Támogatott formátumok: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "Nem található érvényes fájl. Támogatott formátumok: {{formats}}"
   },
   "move": {
     "failed_note": "Hiba a jegyzet mozgatásánál.",

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -231,8 +231,7 @@
   "media": {
     "confirm_delete": "Eliminare \"{{name}}\"?",
     "upload_failed": "Caricamento file fallito",
-    "no_valid_files": "Nessun file valido trovato. Supportati: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "Nessun file valido trovato. Supportati: {{formats}}"
   },
   "move": {
     "failed_note": "Impossibile spostare la nota.",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -231,8 +231,7 @@
   "media": {
     "confirm_delete": "「{{name}}」を削除しますか？",
     "upload_failed": "ファイルのアップロードに失敗しました",
-    "no_valid_files": "有効なファイルが見つかりません。対応: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "有効なファイルが見つかりません。対応: {{formats}}"
   },
   "move": {
     "failed_note": "ノートの移動に失敗しました。",

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -231,8 +231,7 @@
   "media": {
     "confirm_delete": "Удалить «{{name}}»?",
     "upload_failed": "Не удалось загрузить файл",
-    "no_valid_files": "Не найдено подходящих файлов. Поддерживает: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "Не найдено подходящих файлов. Поддерживает: {{formats}}"
   },
   "move": {
     "failed_note": "Не удалось переместить заметку.",

--- a/locales/sl-SI.json
+++ b/locales/sl-SI.json
@@ -231,8 +231,7 @@
   "media": {
     "confirm_delete": "Izbrišem \"{{name}}\"?",
     "upload_failed": "Nalaganje datoteke ni uspelo",
-    "no_valid_files": "Ni najdenih veljavnih datotek. Podprto: JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "Ni najdenih veljavnih datotek. Podprto: {{formats}}"
   },
   "move": {
     "failed_note": "Napaka pri premikanju zapisa.",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -231,8 +231,7 @@
   "media": {
     "confirm_delete": "删除 \"{{name}}\"？",
     "upload_failed": "上传文件失败",
-    "no_valid_files": "未找到有效文件。支持：JPG, PNG, GIF, WebP, MP3, MP4, PDF",
-    "formats": "JPG, PNG, GIF, WebP, MP3, MP4, PDF"
+    "no_valid_files": "未找到有效文件。支持：{{formats}}"
   },
   "move": {
     "failed_note": "移动笔记失败。",


### PR DESCRIPTION
- Now you can also drag `.md` files from the file system into the editor (like other media files): the file is saved as a new note in the current note's folder and a `[name](path.md)` link is inserted at the drop position. Collisions get a timestamp suffix.
- New `UPLOAD_MAX_NOTE_MB` env var (default 10), alongside the existing image/audio/video/PDF limits and exposed via `/api/config`. Enforced client-side because the drop path reads the file into memory.
- External file drags now show the same dashed outline, glow, and drop hint that internal sidebar drags already had. Previously there was no visual feedback at all.
- Localization cleanup: removed the unused `media.formats` key from all 11 locales and moved the format list into a single `MEDIA_FORMATS_DISPLAY` constant via a `{{formats}}` placeholder.