### PR TITLE
Add APP_NAME environment variable to override the app name

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -78,6 +78,15 @@ with open(version_path, 'r', encoding='utf-8') as f:
     version = f.read().strip()
     config['app']['version'] = version
 
+# App name: APP_NAME env var > app.name in config.yaml. An empty value is
+# treated as unset (matches Docker convention and DEFAULT_THEME below), since a
+# blank name would leave the UI and the login page unlabeled.
+_app_name_source = "config.yaml"
+if os.environ.get('APP_NAME', '').strip():
+    config['app']['name'] = os.environ['APP_NAME'].strip()
+    _app_name_source = "APP_NAME env var"
+logger.info("App name: %s (from %s)", config['app']['name'], _app_name_source)
+
 # Environment variable overrides for authentication settings
 # Allows different configs for local vs production deployments
 if 'AUTHENTICATION_ENABLED' in os.environ:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,8 @@
 # NoteDiscovery Configuration
 
 app:
+  # Name shown in the UI, the login page and the browser title.
+  # Override via the APP_NAME env var.
   name: "NoteDiscovery"
   
 server:

--- a/documentation/ENVIRONMENT_VARIABLES.md
+++ b/documentation/ENVIRONMENT_VARIABLES.md
@@ -9,8 +9,27 @@ NoteDiscovery supports environment variables to override configuration settings,
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `PORT` | integer | `8000` | HTTP port for the application (Docker, run.py) |
+| `APP_NAME` | string | `NoteDiscovery` | Name shown in the UI, the login page, the browser title and the API docs. Overrides `app.name` in `config.yaml`. |
 
 > **Note**: Advanced server settings (CORS origins, debug mode) are configured via `config.yaml` only, not via environment variables. See [config.yaml](#advanced-server-configuration) for details.
+
+#### Example: Naming your instance
+
+```bash
+# Docker
+docker run -e APP_NAME="My Notes" ...
+
+# Docker Compose
+environment:
+  - APP_NAME=My Notes
+```
+
+Equivalent in `config.yaml`:
+
+```yaml
+app:
+  name: "My Notes"
+```
 
 ### Storage
 


### PR DESCRIPTION
`app.name` is currently reachable only through `config.yaml`, and that file lives inside the application directory, so a container deployment cannot set it without baking in or mounting over a copy of the file. Mounting a copy means re-reconciling it on every upgrade, which is awkward for a setting that is one string.

This adds `APP_NAME` as an override, following the same shape as the existing variables: env var beats `config.yaml`, the resolved value is logged with its source at startup, and an empty value is treated as unset the way `DEFAULT_THEME` already does (a blank name would leave the UI and the login page unlabeled).

```
INFO:     App name: My Notes (from APP_NAME env var)
INFO:     App name: NoteDiscovery (from config.yaml)
```

The override runs before the FastAPI app is constructed, so the API docs title picks it up along with everything that reads `config['app']['name']` per request.

Also documents the variable in `documentation/ENVIRONMENT_VARIABLES.md` (Core Settings table plus an example, with the `config.yaml` equivalent alongside it, matching the existing entries) and notes the override in `config.yaml` next to the key, as `autosave_delay_ms` and `default_theme` already do.

Nothing changes for an existing deployment that does not set the variable.

## Testing

Imported the module with the variable unset, set to a name, and set to whitespace only, confirming the resolved name, the log line and its source, and the FastAPI title in each case. With `APP_NAME="My Notes"`, `/health` reports `"app": "My Notes"` and the login page renders `<title>My Notes</title>`, which covers both the request-time consumers and the whole-page replacement.
