### PR TITLE
fix: disable credentials when CORS allows wildcard origins

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -585,7 +585,7 @@ def verify_password(password: str) -> bool:
     try:
         return bcrypt.checkpw(password.encode('utf-8'), password_hash.encode('utf-8'))
     except Exception as e:
-        logger.error("Password verification error occurred")
+        logger.error("Password verification error: %s", e)
         return False
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -204,10 +204,13 @@ app = FastAPI(
 # CORS middleware configuration
 # Use config.yaml to control allowed origins (default: ["*"] for self-hosted simplicity)
 allowed_origins = config.get('server', {}).get('allowed_origins', ["*"])
+# Credentials must not be sent with wildcard origins (CORS spec disallows it and
+# browsers reject it; explicitly disable to avoid misconfiguration).
+_allow_credentials = "*" not in allowed_origins
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
-    allow_credentials=True,
+    allow_credentials=_allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -582,7 +585,7 @@ def verify_password(password: str) -> bool:
     try:
         return bcrypt.checkpw(password.encode('utf-8'), password_hash.encode('utf-8'))
     except Exception as e:
-        logger.error("Password verification error: %s", e)
+        logger.error("Password verification error occurred")
         return False
 
 


### PR DESCRIPTION
## Summary

Starlette does not reject \`allow_origins=["*"]\` paired with \`allow_credentials=True\`; instead it silently reflects the requesting \`Origin\` header once a cookie is present, which defeats the wildcard "restriction." This makes the misconfiguration invisible to operators.

**Fix:** compute \`allow_credentials\` from the configured origins list — \`False\` when \`"*"\` is present, \`True\` only when explicit origins are listed. Deployments that already enumerate allowed origins are unaffected.

No CSRF-token changes are included; \`SameSite=Lax\` cookies plus POST/PUT/DELETE-only state-changing endpoints already cover the primary CSRF vector. A separate issue should be opened if full CSRF tokens are desired.

## Files changed

- \`backend/main.py\`: \`allow_credentials\` is now \`"*" not in allowed_origins\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)