### PR TITLE
Feature/display path in search

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1944,9 +1944,10 @@
                                         class="hover-accent px-2 py-1.5 text-sm cursor-pointer mb-1"
                                         :class="{'active': currentNote === note.path}"
                                         :style="currentNote === note.path ? 'background-color: var(--accent-light); color: var(--accent-primary);' : 'color: var(--text-primary);'"
+                                        :title="note.path"
                                     >
-                                        <div class="font-medium truncate" x-text="note.name" :title="note.name"></div>
-                                        <div class="text-xs truncate" style="color: var(--text-tertiary);" x-html="(note.matches && note.matches.length > 0) ? note.matches[0].context : (note.folder || 'Root')" :title="note.folder || 'Root'"></div>
+                                        <div class="font-medium truncate" x-text="note.name"></div>
+                                        <div class="text-xs truncate" style="color: var(--text-tertiary);" x-html="(note.matches && note.matches.length > 0) ? note.matches[0].context : (note.folder || 'Root')"></div>
                     </div>
                 </template>
             </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2046,7 +2046,7 @@
                                             :class="{'active': currentNote === note.path}"
                                             :style="currentNote === note.path ? 'background-color: var(--accent-light); color: var(--accent-primary);' : 'color: var(--text-primary);'"
                                         >
-                                            <span class="truncate block" x-text="note.name" :title="note.name"></span>
+                                            <span class="truncate block" x-text="note.name" :title="note.path"></span>
                                         </div>
                                     </template>
                                     <div x-show="searchResults.length === 0" class="px-3 py-4 text-center text-xs" style="color: var(--text-tertiary);" x-text="t('tags.no_matches')">


### PR DESCRIPTION
When looking at search result you don't see the folder structure behind the result. This shows the path to the note relativ to the data dir.
<img width="609" height="376" alt="Screenshot 2026-08-11 112134" src="https://github.com/user-attachments/assets/e620311b-adae-4118-9846-70f9d00fb673" />
