### PR TITLE
Show full note path in search result tooltips

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1945,8 +1945,8 @@
                                         :class="{'active': currentNote === note.path}"
                                         :style="currentNote === note.path ? 'background-color: var(--accent-light); color: var(--accent-primary);' : 'color: var(--text-primary);'"
                                     >
-                                        <div class="font-medium truncate" x-text="note.name" :title="note.name"></div>
-                                        <div class="text-xs truncate" style="color: var(--text-tertiary);" x-html="(note.matches && note.matches.length > 0) ? note.matches[0].context : (note.folder || 'Root')" :title="note.folder || 'Root'"></div>
+                                        <div class="font-medium truncate" x-text="note.name" :title="note.path"></div>
+                                        <div class="text-xs truncate" style="color: var(--text-tertiary);" x-html="(note.matches && note.matches.length > 0) ? note.matches[0].context : (note.folder || 'Root')" :title="note.path"></div>
                     </div>
                 </template>
             </div>


### PR DESCRIPTION
## What this changes

In the sidebar search results, both rows of each hit carried a tooltip that
added no information:

- the **name** row repeated the visible name (`:title="note.name"`)
- the **snippet** row showed only the folder (`:title="note.folder || 'Root'"`)

When several notes share a basename across folders, the results are
indistinguishable on hover — you have to open one to find out which is which.

Both `:title` bindings now use `note.path`, so hovering anywhere in a result
reveals the vault-relative path, e.g. `Projects/2026/Kickoff.md`. A note at the
vault root shows just `Kickoff.md`.

**Visible text is unchanged** — still the note name on top and the highlighted
match snippet below. Two lines in `frontend/index.html`, nothing else.

## Why no backend change

`search_notes()` (`backend/utils.py:604-609`) already returns `path` on every
result — the Alpine loop even keys on it (`:key="note.path"`). The tag-filtered
mode that reuses `searchResults` gets `path` from `get_notes_by_tag()` too, so
the binding is populated in both modes.

## Scope

Deliberately limited to the sidebar search panel. The quick switcher, the
tag-filtered list and the shared-notes panel keep their current name/folder
tooltips.

## Testing

Ran locally (`python run.py`) against a throwaway vault with three notes all
named `Kickoff.md`, at the root, in `Projects/2026/` and in `Archive/2024/`.

`GET /api/search?q=kickoff+planning` returns all three; the rendered DOM was
read back from a headless Chrome session after driving the real search flow:

| visible name | name row `title` | snippet row `title` |
|---|---|---|
| Kickoff | `Archive/2024/Kickoff.md` | `Archive/2024/Kickoff.md` |
| Kickoff | `Kickoff.md` | `Kickoff.md` |
| Kickoff | `Projects/2026/Kickoff.md` | `Projects/2026/Kickoff.md` |

Also checked:

- the snippet row still renders the highlighted match
  (`...ved note about <mark class="search-highlight">kickoff planning</mark>...`),
  so only the tooltip changed, not the content
- root-level note yields `Kickoff.md` — no leading slash, no empty tooltip
- quick switcher still shows the bare name (`title="Kickoff"`), i.e. untouched
- no Alpine binding warnings in the console

Screenshots aren't very useful here since native `title` tooltips don't appear
in captures; the rendered attribute values above are the direct evidence. The
search panel itself looks identical before and after.
