### PR TITLE
Show full note path in search result tooltips

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1945,8 +1945,8 @@
                                         :class="{'active': currentNote === note.path}"
                                         :style="currentNote === note.path ? 'background-color: var(--accent-light); color: var(--accent-primary);' : 'color: var(--text-primary);'"
                                     >
-                                        <div class="font-medium truncate" x-text="note.name" :title="note.name"></div>
-                                        <div class="text-xs truncate" style="color: var(--text-tertiary);" x-html="(note.matches && note.matches.length > 0) ? note.matches[0].context : (note.folder || 'Root')" :title="note.folder || 'Root'"></div>
+                                        <div class="font-medium truncate" x-text="note.name" :title="note.path"></div>
+                                        <div class="text-xs truncate" style="color: var(--text-tertiary);" x-html="(note.matches && note.matches.length > 0) ? note.matches[0].context : (note.folder || 'Root')" :title="note.path"></div>
                     </div>
                 </template>
             </div>


### PR DESCRIPTION
<img width="385" height="268" alt="image" src="https://github.com/user-attachments/assets/3e9b3178-07f4-4ab9-b316-fb107ab045e6" />

show the path to a note on mouse over in search result.

P.S: @gamosoft Sorry, i'm still learning to use git probably....